### PR TITLE
Make BaseURL configurable via constructor

### DIFF
--- a/bulk_balance_sheet_growth.go
+++ b/bulk_balance_sheet_growth.go
@@ -84,7 +84,7 @@ func (c *Client) GetBalanceSheetGrowthBulk(params BalanceSheetGrowthBulkParams) 
 	}
 
 	// Build the URL
-	baseURL := "https://financialmodelingprep.com/stable/balance-sheet-statement-growth-bulk"
+	baseURL := c.BaseURL + "/balance-sheet-statement-growth-bulk"
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %w", err)

--- a/bulk_cash_flow_statement.go
+++ b/bulk_cash_flow_statement.go
@@ -75,7 +75,7 @@ func (c *Client) GetCashFlowStatementBulk(params CashFlowStatementBulkParams) ([
 	}
 
 	// Build the URL
-	baseURL := "https://financialmodelingprep.com/stable/cash-flow-statement-bulk"
+	baseURL := c.BaseURL + "/cash-flow-statement-bulk"
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %w", err)

--- a/bulk_cash_flow_statement_growth.go
+++ b/bulk_cash_flow_statement_growth.go
@@ -70,7 +70,7 @@ func (c *Client) GetCashFlowStatementGrowthBulk(params CashFlowStatementGrowthBu
 	}
 
 	// Build the URL
-	baseURL := "https://financialmodelingprep.com/stable/cash-flow-statement-growth-bulk"
+	baseURL := c.BaseURL + "/cash-flow-statement-growth-bulk"
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %w", err)

--- a/bulk_dcf.go
+++ b/bulk_dcf.go
@@ -18,7 +18,7 @@ type DCFBulkResponse struct {
 // GetDCFBulk retrieves discounted cash flow valuations for multiple symbols
 func (c *Client) GetDCFBulk() ([]DCFBulkResponse, error) {
 	// Build the URL
-	baseURL := "https://financialmodelingprep.com/stable/dcf-bulk"
+	baseURL := c.BaseURL + "/dcf-bulk"
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %w", err)

--- a/bulk_earnings_surprises.go
+++ b/bulk_earnings_surprises.go
@@ -29,7 +29,7 @@ func (c *Client) GetEarningsSurprisesBulk(params EarningsSurprisesBulkParams) ([
 	}
 
 	// Build the URL
-	baseURL := "https://financialmodelingprep.com/stable/earnings-surprises-bulk"
+	baseURL := c.BaseURL + "/earnings-surprises-bulk"
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %w", err)

--- a/bulk_eod.go
+++ b/bulk_eod.go
@@ -32,7 +32,7 @@ func (c *Client) GetEODBulk(params EODBulkParams) ([]EODBulkResponse, error) {
 	}
 
 	// Build the URL
-	baseURL := "https://financialmodelingprep.com/stable/eod-bulk"
+	baseURL := c.BaseURL + "/eod-bulk"
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %w", err)

--- a/bulk_etf_holder.go
+++ b/bulk_etf_holder.go
@@ -33,7 +33,7 @@ func (c *Client) ETFHolderBulk(params ETFHolderBulkParams) ([]ETFHolderBulkRespo
 	}
 
 	// Build the URL
-	baseURL := "https://financialmodelingprep.com/stable/etf-holder-bulk"
+	baseURL := c.BaseURL + "/etf-holder-bulk"
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %w", err)

--- a/bulk_income_statement.go
+++ b/bulk_income_statement.go
@@ -67,7 +67,7 @@ func (c *Client) GetIncomeStatementBulk(params IncomeStatementBulkParams) ([]Inc
 	}
 
 	// Build the URL
-	baseURL := "https://financialmodelingprep.com/stable/income-statement-bulk"
+	baseURL := c.BaseURL + "/income-statement-bulk"
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %w", err)

--- a/bulk_income_statement_growth.go
+++ b/bulk_income_statement_growth.go
@@ -62,7 +62,7 @@ func (c *Client) GetIncomeStatementGrowthBulk(params IncomeStatementGrowthBulkPa
 	}
 
 	// Build the URL
-	baseURL := "https://financialmodelingprep.com/stable/income-statement-growth-bulk"
+	baseURL := c.BaseURL + "/income-statement-growth-bulk"
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %w", err)

--- a/bulk_key_metrics_ttm.go
+++ b/bulk_key_metrics_ttm.go
@@ -57,7 +57,7 @@ type KeyMetricsTTMBulkResponse struct {
 // GetKeyMetricsTTMBulk retrieves trailing twelve months data for all companies
 func (c *Client) GetKeyMetricsTTMBulk() ([]KeyMetricsTTMBulkResponse, error) {
 	// Build the URL
-	baseURL := "https://financialmodelingprep.com/stable/key-metrics-ttm-bulk"
+	baseURL := c.BaseURL + "/key-metrics-ttm-bulk"
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %w", err)

--- a/bulk_peers.go
+++ b/bulk_peers.go
@@ -16,7 +16,7 @@ type PeersBulkResponse struct {
 // GetPeersBulk retrieves peer companies for all stocks in the database
 func (c *Client) GetPeersBulk() ([]PeersBulkResponse, error) {
 	// Build the URL
-	baseURL := "https://financialmodelingprep.com/stable/peers-bulk"
+	baseURL := c.BaseURL + "/peers-bulk"
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %w", err)

--- a/bulk_price_target_summary.go
+++ b/bulk_price_target_summary.go
@@ -24,7 +24,7 @@ type PriceTargetSummaryBulkResponse struct {
 // GetPriceTargetSummaryBulk retrieves comprehensive overview of price targets for all listed symbols
 func (c *Client) GetPriceTargetSummaryBulk() ([]PriceTargetSummaryBulkResponse, error) {
 	// Build the URL
-	baseURL := "https://financialmodelingprep.com/stable/price-target-summary-bulk"
+	baseURL := c.BaseURL + "/price-target-summary-bulk"
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %w", err)

--- a/bulk_profile.go
+++ b/bulk_profile.go
@@ -60,7 +60,7 @@ func (c *Client) GetProfileBulk(params ProfileBulkParams) ([]ProfileBulkResponse
 	}
 
 	// Build the URL
-	baseURL := "https://financialmodelingprep.com/stable/profile-bulk"
+	baseURL := c.BaseURL + "/profile-bulk"
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %w", err)

--- a/bulk_rating.go
+++ b/bulk_rating.go
@@ -23,7 +23,7 @@ type RatingBulkResponse struct {
 // GetRatingBulk retrieves comprehensive rating data for multiple stocks
 func (c *Client) GetRatingBulk() ([]RatingBulkResponse, error) {
 	// Build the URL
-	baseURL := "https://financialmodelingprep.com/stable/rating-bulk"
+	baseURL := c.BaseURL + "/rating-bulk"
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %w", err)

--- a/bulk_ratios_ttm.go
+++ b/bulk_ratios_ttm.go
@@ -74,7 +74,7 @@ type RatiosTTMBulkResponse struct {
 // GetRatiosTTMBulk retrieves trailing twelve months financial ratios for stocks
 func (c *Client) GetRatiosTTMBulk() ([]RatiosTTMBulkResponse, error) {
 	// Build the URL
-	baseURL := "https://financialmodelingprep.com/stable/ratios-ttm-bulk"
+	baseURL := c.BaseURL + "/ratios-ttm-bulk"
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %w", err)

--- a/bulk_scores.go
+++ b/bulk_scores.go
@@ -25,7 +25,7 @@ type ScoresBulkResponse struct {
 // ScoresBulk retrieves key financial scores and metrics for multiple symbols
 func (c *Client) ScoresBulk() ([]ScoresBulkResponse, error) {
 	// Build the URL
-	baseURL := "https://financialmodelingprep.com/stable/scores-bulk"
+	baseURL := c.BaseURL + "/scores-bulk"
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %w", err)

--- a/bulk_upgrades_downgrades_consensus.go
+++ b/bulk_upgrades_downgrades_consensus.go
@@ -21,7 +21,7 @@ type UpgradesDowngradesConsensusBulkResponse struct {
 // UpgradesDowngradesConsensusBulk retrieves analyst ratings across all symbols
 func (c *Client) UpgradesDowngradesConsensusBulk() ([]UpgradesDowngradesConsensusBulkResponse, error) {
 	// Build the URL
-	baseURL := "https://financialmodelingprep.com/stable/upgrades-downgrades-consensus-bulk"
+	baseURL := c.BaseURL + "/upgrades-downgrades-consensus-bulk"
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %w", err)

--- a/client.go
+++ b/client.go
@@ -15,17 +15,21 @@ type HTTPClient interface {
 type Client struct {
 	HTTPClient HTTPClient
 	APIKey     string
+	BaseURL    string
 }
 
 // NewClient creates a new Client. If httpClient is nil, http.DefaultClient is used.
-func NewClient(httpClient HTTPClient, apiKey string) (*Client, error) {
+func NewClient(httpClient HTTPClient, apiKey string, baseURL string) (*Client, error) {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-
+	if baseURL == "" {
+		baseURL = "https://financialmodelingprep.com/stable"
+	}
 	newClient := &Client{
 		HTTPClient: httpClient,
 		APIKey:     apiKey,
+		BaseURL:    baseURL,
 	}
 
 	err := testClient(newClient)


### PR DESCRIPTION
Make the API client's base URL configurable via the constructor to allow for custom endpoints.